### PR TITLE
Don't set http request content when it's empty

### DIFF
--- a/PayU.Client/src/PayU.Client/Builders/PayUClientRequestBuilder.cs
+++ b/PayU.Client/src/PayU.Client/Builders/PayUClientRequestBuilder.cs
@@ -30,7 +30,12 @@ namespace PayU.Client.Builders
             message.Headers.Accept.Add(PayUContainer.ContentJson);
             message.Method = method;
             message.RequestUri = url;
-            message.Content = new JsonContent(content, PayUContainer.JsonSerializer);
+            
+            if (content != null)
+            {
+                message.Content = new JsonContent(content, PayUContainer.JsonSerializer);
+            }
+            
             return message;
         }
 


### PR DESCRIPTION
Despite JsonSerializer.NullValueHandling set to Ignore, this produces non empty content for GET request which ends with exception.

NullValueHandling Ignore works like this:
- for: `content = new { A = "test", "B" = null }` it produces: `"{"A":"test"}"` // no "B" here since it's null, this is OK
- for: `content = new {}` it produces: `"{}"` // this ends with exception when send it in GET
- for: `content = null` it produces: `"null"` // again the exception